### PR TITLE
Fix mixed up `serializeB64`/`serializeHex`

### DIFF
--- a/biscuit-servant/test/Spec.hs
+++ b/biscuit-servant/test/Spec.hs
@@ -46,7 +46,7 @@ appPrivateKey :: PrivateKey
 appPrivateKey = fromJust . parsePrivateKeyHex $ "c2b7507af4f849fd028d0f7e90b04a4e74d9727b358fca18b65beffd86c47209"
 
 toText :: Biscuit -> Text
-toText = decodeUtf8 . serializeHex
+toText = decodeUtf8 . serializeB64
 
 mkAdminBiscuit :: Keypair -> IO Biscuit
 mkAdminBiscuit kp = mkBiscuit kp [block|right(#authority, #admin);|]

--- a/biscuit/src/Auth/Biscuit.hs
+++ b/biscuit/src/Auth/Biscuit.hs
@@ -182,9 +182,9 @@ serialize = serializeBiscuit
 
 -- | Serialize a biscuit to URL-compatible base 64, as recommended by the spec
 serializeB64 :: Biscuit -> ByteString
-serializeB64 = Hex.encode . serialize
+serializeB64 = B64.encodeBase64' . serialize
 
 -- | Serialize a biscuit to a hex (base 16) string. Be advised that the specs
 -- recommends base 64 instead.
 serializeHex :: Biscuit -> ByteString
-serializeHex = B64.encodeBase64' . serialize
+serializeHex = Hex.encode . serialize


### PR DESCRIPTION
`serializeB64` had an hex output, and `serializeHex` had a b64 output.

The fix comes with extra tests, as well as a correction in `biscuit-servant`
tests (the tests worked around the issue by using the wrong function).