### PR TITLE
Release `biscuit-haskell-0.1.1.0` with a bug fix & sync biscuit-servant

### DIFF
--- a/biscuit-servant/ChangeLog.md
+++ b/biscuit-servant/ChangeLog.md
@@ -1,0 +1,5 @@
+# Changelog for biscuit-servant
+
+## 0.1.1.0
+
+Initial release

--- a/biscuit-servant/LICENSE
+++ b/biscuit-servant/LICENSE
@@ -1,0 +1,30 @@
+Copyright Clément Delafargue (c) 2020
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Author name here nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/biscuit-servant/README.md
+++ b/biscuit-servant/README.md
@@ -1,0 +1,1 @@
+# Biscuit-based auth for servant apps

--- a/biscuit-servant/biscuit-servant.cabal
+++ b/biscuit-servant/biscuit-servant.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.0
 
 name:           biscuit-servant
-version:        0.1.0.0
+version:        0.1.1.0
 category:       Security
 synopsis:       Servant support for the Biscuit security token
 description:    Please see the README on GitHub at <https://github.com/divarvel/biscuit-haskell#readme>

--- a/biscuit/ChangeLog.md
+++ b/biscuit/ChangeLog.md
@@ -1,3 +1,9 @@
 # Changelog for biscuit-haskell
 
-## Unreleased changes
+## 0.1.1.0
+
+Bugfix for `serializeB64` and `serializeHex`.
+
+## 0.1.0.0
+
+Basic biscuit support.

--- a/biscuit/biscuit-haskell.cabal
+++ b/biscuit/biscuit-haskell.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.0
 
 name:           biscuit-haskell
-version:        0.1.0.0
+version:        0.1.1.0
 category:       Security
 synopsis:       Library support for the Biscuit security token
 description:    Please see the README on GitHub at <https://github.com/divarvel/biscuit-haskell#readme>


### PR DESCRIPTION
biscuit-servant has not been released on hackage yet, but I'd like to keep version numbers in sync as much as possible.