### PR TITLE
biscuit-servant: allow effectful verification

### DIFF
--- a/biscuit-servant/biscuit-servant.cabal
+++ b/biscuit-servant/biscuit-servant.cabal
@@ -62,5 +62,6 @@ test-suite biscuit-servant-test
     , servant-client
     , servant-client-core
     , text
+    , time
     , warp
   default-language: Haskell2010


### PR DESCRIPTION
`withVerifier`, `withPriorityVerifier` and `withFallbackVerifier` now have `-M` variants, where the verifier is in a monadic context (for convenience, the same context as the handler itself). This means that the verifier context can return http errors itself. I don't expect to use this feature, but it's there. The most common uses for effectful verifiers will be:
- running `IO` to get the current time
- running `IO` plus accessing a `Reader` context to query the database