### PR TITLE
biscuit: update parser to conform to the EBNF grammar

### DIFF
--- a/biscuit/test/Spec/Parser.hs
+++ b/biscuit/test/Spec/Parser.hs
@@ -43,6 +43,7 @@ specs :: TestTree
 specs = testGroup "datalog parser"
   [ factWithDate
   , simpleFact
+  , oneLetterFact
   , simpleRule
   , multilineRule
   , termsGroup
@@ -81,6 +82,11 @@ simpleFact :: TestTree
 simpleFact = testCase "Parse simple fact" $
   parsePredicate "right(\"file1\", \"read\")" @?=
     Right (Predicate "right" [LString "file1", LString "read"])
+
+oneLetterFact :: TestTree
+oneLetterFact = testCase "Parse one-letter fact" $
+  parsePredicate "a(12)" @?=
+    Right (Predicate "a" [LInteger 12])
 
 factWithDate :: TestTree
 factWithDate = testCase "Parse fact containing a date" $


### PR DESCRIPTION
The EBNF grammar defined in https://github.com/CleverCloud/biscuit/issues/82
makes the parsing rules a bit more explicit:

- fact names can only start with a letter