### PR TITLE
biscuit: don't discard errors in datalog quasiquotes

### DIFF
--- a/biscuit/src/Auth/Biscuit/Datalog/Parser.hs
+++ b/biscuit/src/Auth/Biscuit/Datalog/Parser.hs
@@ -344,7 +344,7 @@ policyParser = do
   (policy, ) <$> queryParser
 
 compileParser :: Lift a => Parser a -> String -> Q Exp
-compileParser p str = case parseOnly p (pack str) of
+compileParser p str = case parseOnly (p <* skipSpace <* endOfInput) (pack str) of
   Right result -> [| result |]
   Left e       -> fail e
 


### PR DESCRIPTION
This commit makes sure that all the datalog code provided in quasiquotes
is consumed by the parser. This avoids silent failures (if a parser fails,
the input is simply not consumed and the error is silently discarded).