### PR TITLE
Relax dependencies bounds and bump base16-bytestring

### DIFF
--- a/biscuit/app/Main.hs
+++ b/biscuit/app/Main.hs
@@ -1,4 +1,0 @@
-module Main where
-
-main :: IO ()
-main = putStrLn "todo"

--- a/biscuit/biscuit-haskell.cabal
+++ b/biscuit/biscuit-haskell.cabal
@@ -45,11 +45,11 @@ library
   build-depends:
     base                 >= 4.7 && <5,
     async                ^>= 2.2,
-    base16-bytestring    ^>= 0.1.0,
+    base16-bytestring    ^>= 1.0,
     bytestring           ^>= 0.10,
     text                 ^>= 1.2,
     containers           ^>= 0.6,
-    cryptonite           ^>= 0.27,
+    cryptonite           >= 0.27 && < 0.30,
     memory               ^>= 0.15,
     template-haskell     ^>= 2.16,
     attoparsec           ^>= 0.13,
@@ -58,7 +58,7 @@ library
     mtl                  ^>= 2.2,
     parser-combinators   ^>= 1.2,
     protobuf             ^>= 0.2,
-    random               ^>= 1.1,
+    random               >= 1.0 && < 1.3,
     regex-tdfa           ^>= 1.3,
     th-lift-instances    ^>= 0.1,
     time                 ^>= 1.9,
@@ -76,7 +76,7 @@ executable biscuit-haskell-exe
       async
     , attoparsec
     , base >=4.7 && <5
-    , base16-bytestring ^>=0.1.0
+    , base16-bytestring ^>=1.0
     , base64
     , biscuit-haskell
     , bytestring
@@ -115,7 +115,7 @@ test-suite biscuit-haskell-test
     , aeson
     , attoparsec
     , base >=4.7 && <5
-    , base16-bytestring ^>=0.1
+    , base16-bytestring ^>=1.0
     , base64
     , biscuit-haskell
     , bytestring

--- a/biscuit/biscuit-haskell.cabal
+++ b/biscuit/biscuit-haskell.cabal
@@ -65,34 +65,6 @@ library
     validation-selective ^>= 0.1
   default-language: Haskell2010
 
-executable biscuit-haskell-exe
-  main-is: Main.hs
-  other-modules:
-      Paths_biscuit_haskell
-  hs-source-dirs:
-      app
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall
-  build-depends:
-      async
-    , attoparsec
-    , base >=4.7 && <5
-    , base16-bytestring ^>=1.0
-    , base64
-    , biscuit-haskell
-    , bytestring
-    , cereal
-    , containers
-    , mtl
-    , parser-combinators
-    , protobuf
-    , random
-    , template-haskell
-    , text
-    , th-lift-instances
-    , time
-    , validation-selective
-  default-language: Haskell2010
-
 test-suite biscuit-haskell-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs

--- a/biscuit/src/Auth/Biscuit.hs
+++ b/biscuit/src/Auth/Biscuit.hs
@@ -232,9 +232,7 @@ blockContext c = mempty { bContext = Just c }
 
 -- | Decode a base16-encoded bytestring, reporting errors via `MonadFail`
 fromHex :: MonadFail m => ByteString -> m ByteString
-fromHex input = do
-  (decoded, "") <- pure $ Hex.decode input
-  pure decoded
+fromHex = either fail pure . Hex.decode
 
 -- $keypairs
 --

--- a/biscuit/src/Auth/Biscuit/Datalog/Parser.hs
+++ b/biscuit/src/Auth/Biscuit/Datalog/Parser.hs
@@ -213,8 +213,7 @@ binary name op = Expr.InfixL  (EBinary op <$ (skipSpace *> string name))
 hexBsParser :: Parser ByteString
 hexBsParser = do
   void $ string "hex:"
-  (digits, "") <- Hex.decode . encodeUtf8 <$> takeWhile1 (inClass "0-9a-fA-F")
-  pure digits
+  either fail pure =<< Hex.decode . encodeUtf8 <$> takeWhile1 (inClass "0-9a-fA-F")
 
 litStringParser :: Parser Text
 litStringParser =


### PR DESCRIPTION
This will keep dependencies aligned with the latest stackage LTS