### PR TITLE
Bump version

### DIFF
--- a/biscuit-servant/biscuit-servant.cabal
+++ b/biscuit-servant/biscuit-servant.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.0
 
 name:           biscuit-servant
-version:        0.2.0.0
+version:        0.2.0.1
 category:       Security
 synopsis:       Servant support for the Biscuit security token
 description:    Please see the README on GitHub at <https://github.com/divarvel/biscuit-haskell#readme>

--- a/biscuit/biscuit-haskell.cabal
+++ b/biscuit/biscuit-haskell.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.0
 
 name:           biscuit-haskell
-version:        0.2.0.0
+version:        0.2.0.1
 category:       Security
 synopsis:       Library support for the Biscuit security token
 description:    Please see the README on GitHub at <https://github.com/divarvel/biscuit-haskell#readme>


### PR DESCRIPTION
Version 0.2.0.0 was erroneously published with outdated code
(including outdated version bounds)